### PR TITLE
Handling 5xx Errors from the Twitch API

### DIFF
--- a/tests/api/dummy_credentials.cfg
+++ b/tests/api/dummy_credentials.cfg
@@ -1,3 +1,7 @@
 [Credentials]
 client_id = spongebob
 oauth_token = squarepants
+
+[General]
+initial_backoff = 0.01
+max_retries = 1

--- a/tests/api/test_base.py
+++ b/tests/api/test_base.py
@@ -1,4 +1,5 @@
 import json
+import os
 
 import pytest
 
@@ -73,11 +74,16 @@ def test_request_get_sends_headers_with_the_request():
     (500),
     (400),
 ])
-def test_request_get_raises_exception_if_not_200_response(status):
+def test_request_get_raises_exception_if_not_200_response(status, monkeypatch):
     responses.add(responses.GET,
                   BASE_URL,
                   status=status,
                   content_type='application/json')
+
+    def mockreturn(path):
+        return 'tests/api/dummy_credentials.cfg'
+
+    monkeypatch.setattr(os.path, 'expanduser', mockreturn)
 
     api = TwitchAPI(client_id='client')
 

--- a/tests/api/test_base.py
+++ b/tests/api/test_base.py
@@ -261,3 +261,17 @@ def test_request_post_raises_exception_if_not_200_response(status):
 
     with pytest.raises(exceptions.HTTPError):
         api._request_post('', dummy_data)
+
+
+def test_base_reads_backoff_config_from_file(monkeypatch):
+    def mockreturn(path):
+        return 'tests/api/dummy_credentials.cfg'
+
+    monkeypatch.setattr(os.path, 'expanduser', mockreturn)
+
+    base = TwitchAPI(client_id='client')
+
+    assert isinstance(base._initial_backoff, float)
+    assert isinstance(base._max_retries, int)
+    assert base._initial_backoff == 0.01
+    assert base._max_retries == 1

--- a/twitch/api/base.py
+++ b/twitch/api/base.py
@@ -1,7 +1,22 @@
+import time
+
 import requests
 from requests.compat import urljoin
 
 from twitch.constants import BASE_URL
+
+
+def _backoff(url, params, headers, original_response, initial_backoff=0.5, max_retries=3):
+    backoff = initial_backoff
+
+    for _ in range(max_retries):
+        time.sleep(backoff)
+        response = requests.get(url, params=params, headers=headers)
+        if response.status_code < 500:
+            return response
+        backoff *= 2
+
+    return original_response
 
 
 class TwitchAPI(object):
@@ -28,6 +43,8 @@ class TwitchAPI(object):
         headers = self._get_request_headers()
 
         response = requests.get(url, params=params, headers=headers)
+        if response.status_code >= 500:
+            response = _backoff(url, params, headers, response)
         response.raise_for_status()
         return response.json()
 

--- a/twitch/api/base.py
+++ b/twitch/api/base.py
@@ -1,5 +1,5 @@
-import time
 import os
+import time
 from configparser import ConfigParser
 
 import requests

--- a/twitch/api/base.py
+++ b/twitch/api/base.py
@@ -6,19 +6,6 @@ from requests.compat import urljoin
 from twitch.constants import BASE_URL
 
 
-def _backoff(url, params, headers, original_response, initial_backoff=0.5, max_retries=3):
-    backoff = initial_backoff
-
-    for _ in range(max_retries):
-        time.sleep(backoff)
-        response = requests.get(url, params=params, headers=headers)
-        if response.status_code < 500:
-            return response
-        backoff *= 2
-
-    return original_response
-
-
 class TwitchAPI(object):
 
     def __init__(self, client_id, oauth_token=None, *args, **kwargs):
@@ -44,7 +31,16 @@ class TwitchAPI(object):
 
         response = requests.get(url, params=params, headers=headers)
         if response.status_code >= 500:
-            response = _backoff(url, params, headers, response)
+
+            backoff = 0.5
+            for _ in range(3):
+                time.sleep(backoff)
+                backoff_response = requests.get(url, params=params, headers=headers)
+                if backoff_response.status_code < 500:
+                    response = backoff_response
+                    break
+                backoff *= 2
+
         response.raise_for_status()
         return response.json()
 

--- a/twitch/client.py
+++ b/twitch/client.py
@@ -1,12 +1,11 @@
 import os
 from configparser import ConfigParser
 
+from .constants import CONFIG_FILE_PATH
 from .api import (
     ChannelFeed, Channels, Chat, Collections, Communities, Games, Ingests, Search, Streams, Teams,
     Users, Videos
 )
-
-CONFIG_FILE_PATH = '~/.twitch.cfg'
 
 
 class TwitchClient(object):

--- a/twitch/client.py
+++ b/twitch/client.py
@@ -1,11 +1,11 @@
 import os
 from configparser import ConfigParser
 
-from .constants import CONFIG_FILE_PATH
 from .api import (
     ChannelFeed, Channels, Chat, Collections, Communities, Games, Ingests, Search, Streams, Teams,
     Users, Videos
 )
+from .constants import CONFIG_FILE_PATH
 
 
 class TwitchClient(object):

--- a/twitch/constants.py
+++ b/twitch/constants.py
@@ -45,3 +45,5 @@ STREAM_TYPES = [
     STREAM_TYPE_PLAYLIST,
     STREAM_TYPE_ALL
 ]
+
+CONFIG_FILE_PATH = '~/.twitch.cfg'


### PR DESCRIPTION
As described in #16, this implements backoff functionality when a HTTP GET request to the Twitch API returns a 5xx error code, which appears to be quite common. 
Users are able to configure the initial backoff and the maximum retries for 500 errors in the `[General]` section of the `~/.twitch.cfg` file, for example:
```ini
[Credentials]
# ...

[General]
# Initially back off for half a second
initial_backoff = 0.5

# Retry up to three times
max_retries = 3
```

These values are also the default when the `[General]` section is not present. I also added a test that validates the proper reading of the configuration file.