### PR TITLE
Removed support for python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
     - 2.7
-    - 3.3
     - 3.4
     - 3.5
     - 3.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Master
+
+- Removed support for Python 3.3
+
+
 ## Version 0.5.1 - 2018-03-03
 
 - Fixed `configparser` import for Python<3.2

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -8,6 +8,6 @@ pytest==3.5.1
 requests==2.18.4
 responses==0.9.0
 six==1.11.0
-Sphinx==1.6.7
+Sphinx==1.7.4
 sphinx-autobuild==0.7.1
 sphinx_rtd_theme==0.3.1


### PR DESCRIPTION
Python 3.3 EOL was on 2017-09-29 (source https://devguide.python.org/#branchstatus)