### PR TITLE
If convert_to_twitch_object fails, iterator fails

### DIFF
--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -47,10 +47,12 @@ def test_convert_to_twitch_object_output_returns_correct_object(name, data, expe
     ('created_at', '2016-11-29T15:52:27Z', datetime(2016, 11, 29, 15, 52, 27)),
     ('updated_at', '2017-03-06T18:40:51.855Z', datetime(2017, 3, 6, 18, 40, 51, 855000)),
     ('published_at', '2017-02-14T22:27:54Z', datetime(2017, 2, 14, 22, 27, 54)),
+    ('published_at', None, None),
 ])
 def test_datetimes_are_converted_correctly_to_datetime_objects(name, data, expected):
     result = convert_to_twitch_object(name, data)
-    assert isinstance(result, datetime)
+    if result is not None:
+        assert isinstance(result, datetime)
     assert result == expected
 
 

--- a/twitch/resources.py
+++ b/twitch/resources.py
@@ -4,6 +4,9 @@ import six
 
 
 def convert_to_twitch_object(name, data):
+    if data is None:
+        return None
+
     types = {
         'channel': Channel,
         'videos': Video,

--- a/twitch/resources.py
+++ b/twitch/resources.py
@@ -4,9 +4,6 @@ import six
 
 
 def convert_to_twitch_object(name, data):
-    if data is None:
-        return None
-
     types = {
         'channel': Channel,
         'videos': Video,
@@ -75,6 +72,8 @@ class _DateTime(object):
 
     @classmethod
     def construct_from(cls, value):
+        if value is None:
+            return None
         try:
             dt = datetime.strptime(value, '%Y-%m-%dT%H:%M:%SZ')
         except ValueError:


### PR DESCRIPTION
I'm not a Python expert, so this may not be the best way to approach it, but currently if any of the `special_types`, e.g. `_DateTime`, is `None`, the iterator breaks because it cannot convert a `None` to a `DateTime`.

With this change, we're just letting it be without converting a piece of data that is `None`. Perhaps another solution is to not even enter `convert_to_twitch_object` by skipping it under [`refresh_from`](https://github.com/jvtrigueros/python-twitch-client/blob/9316f6836e4b8546f1433543397f34a590620d08/twitch/resources.py#L71).

If you provide guidance, I can adjust my PR.

Here's an example that reproduces this behaviour:

```python
from twitch import TwitchHelix

client_id = '<REDACTED>'
helix_client = TwitchHelix(client_id=client_id)
video = helix_client.get_videos(video_ids=[367033312])
```
For this specific video, the key `published_at` is `None` thus causing `_DateTime`'s construct method to throw.