### PR TITLE
Added get_users() method to helix api

### DIFF
--- a/twitch/helix/api.py
+++ b/twitch/helix/api.py
@@ -9,7 +9,7 @@ from twitch.constants import (
 )
 from twitch.exceptions import TwitchAttributeException
 from twitch.helix.base import APICursor, APIGet
-from twitch.resources import Clip, Follow, Game, Stream, StreamMetadata, Video
+from twitch.resources import Clip, Follow, Game, Stream, StreamMetadata, Video, User
 
 
 class TwitchHelix(object):
@@ -289,3 +289,20 @@ class TwitchHelix(object):
             resource=Follow,
             params=params,
         )
+
+    def get_users(self, login_names=[], ids=[]):
+        '''https://dev.twitch.tv/docs/api/reference#get-users'''
+        if len(login_names) + len(ids) > 100:
+            raise TwitchAttributeException("Sum of names and ids must not exceed 100!")
+        params = {
+            "login": login_names,
+            "id": ids
+        }
+
+        return APIGet(
+            client_id=self._client_id,
+            oauth_token=self._oauth_token,
+            path="users",
+            resource=User,
+            params=params,
+        ).fetch()


### PR DESCRIPTION
Official documentation: https://dev.twitch.tv/docs/api/reference#get-users

As I needed this for my own stream I added this. Maybe this helps someone. I just started looking at the twitch api a couple of hours ago so there might be errors in this.

Here is a code snippet getting your (mine in this case) latest follower:
```python
from twitch import TwitchHelix
client = TwitchHelix(client_id='...', oauth_token="...")
result = client.get_users("nicfel")
resultTwo = client.get_user_follows(to_id=result[0]["id"], page_size=1)
print(resultTwo[0]["from_name"])
```
