### PR TITLE
Do not install samples

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setuptools.setup(
     author="Tomaz Sifrer",
     author_email="tomazz.sifrer@gmail.com",
     url="https://github.com/tsifrer/python-twitch-client",
-    packages=setuptools.find_packages(exclude=["tests", "tests.*"]),
+    packages=setuptools.find_packages(exclude=["tests", "tests.*", "samples", "samples.*"]),
     cmdclass=cmdclass,
     install_requires=requires,
     tests_require=test_requirements,


### PR DESCRIPTION
Not necessary on installs anyway, and currently also installed as the global top level `samples` package.